### PR TITLE
Go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module tarsnapmanager
+
+go 1.12
+
+require github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tarsnapmanager
+module github.com/jamesog/tarsnapmanager
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28 h1:mkl3tvPHIuPaWsLtmHTybJeoVEW7cbePK73Ir8VtruA=
+github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28/go.mod h1:T/T7jsxVqf9k/zYOqbgNAsANsjxTd1Yq3htjDhQ1H0c=

--- a/vendor/github.com/kylelemons/go-gypsy/LICENSE
+++ b/vendor/github.com/kylelemons/go-gypsy/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/kylelemons/go-gypsy/yaml/Makefile
+++ b/vendor/github.com/kylelemons/go-gypsy/yaml/Makefile
@@ -1,0 +1,9 @@
+include $(GOROOT)/src/Make.inc
+
+TARG=github.com/kylelemons/go-gypsy/yaml
+GOFILES=\
+	types.go\
+	parser.go\
+	config.go\
+
+include $(GOROOT)/src/Make.pkg

--- a/vendor/github.com/kylelemons/go-gypsy/yaml/config.go
+++ b/vendor/github.com/kylelemons/go-gypsy/yaml/config.go
@@ -1,0 +1,285 @@
+// Copyright 2013 Google, Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// A File represents the top-level YAML node found in a file.  It is intended
+// for use as a configuration file.
+type File struct {
+	Root Node
+
+	// TODO(kevlar): Add a cache?
+}
+
+// ReadFile reads a YAML configuration file from the given filename.
+func ReadFile(filename string) (*File, error) {
+	fin, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer fin.Close()
+
+	f := new(File)
+	f.Root, err = Parse(fin)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+// Config reads a YAML configuration from a static string.  If an error is
+// found, it will panic.  This is a utility function and is intended for use in
+// initializers.
+func Config(yamlconf string) *File {
+	var err error
+	buf := bytes.NewBufferString(yamlconf)
+
+	f := new(File)
+	f.Root, err = Parse(buf)
+	if err != nil {
+		panic(err)
+	}
+
+	return f
+}
+
+// ConfigFile reads a YAML configuration file from the given filename and
+// panics if an error is found.  This is a utility function and is intended for
+// use in initializers.
+func ConfigFile(filename string) *File {
+	f, err := ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// Get retrieves a scalar from the file specified by a string of the same
+// format as that expected by Child.  If the final node is not a Scalar, Get
+// will return an error.
+func (f *File) Get(spec string) (string, error) {
+	node, err := Child(f.Root, spec)
+	if err != nil {
+		return "", err
+	}
+
+	if node == nil {
+		return "", &NodeNotFound{
+			Full: spec,
+			Spec: spec,
+		}
+	}
+
+	scalar, ok := node.(Scalar)
+	if !ok {
+		return "", &NodeTypeMismatch{
+			Full:     spec,
+			Spec:     spec,
+			Token:    "$",
+			Expected: "yaml.Scalar",
+			Node:     node,
+		}
+	}
+	return scalar.String(), nil
+}
+
+func (f *File) GetInt(spec string) (int64, error) {
+	s, err := f.Get(spec)
+	if err != nil {
+		return 0, err
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return i, nil
+}
+
+func (f *File) GetBool(spec string) (bool, error) {
+	s, err := f.Get(spec)
+	if err != nil {
+		return false, err
+	}
+
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, err
+	}
+
+	return b, nil
+}
+
+// Count retrieves a the number of elements in the specified list from the file
+// using the same format as that expected by Child.  If the final node is not a
+// List, Count will return an error.
+func (f *File) Count(spec string) (int, error) {
+	node, err := Child(f.Root, spec)
+	if err != nil {
+		return -1, err
+	}
+
+	if node == nil {
+		return -1, &NodeNotFound{
+			Full: spec,
+			Spec: spec,
+		}
+	}
+
+	lst, ok := node.(List)
+	if !ok {
+		return -1, &NodeTypeMismatch{
+			Full:     spec,
+			Spec:     spec,
+			Token:    "$",
+			Expected: "yaml.List",
+			Node:     node,
+		}
+	}
+	return lst.Len(), nil
+}
+
+// Require retrieves a scalar from the file specified by a string of the same
+// format as that expected by Child.  If the final node is not a Scalar, String
+// will panic.  This is a convenience function for use in initializers.
+func (f *File) Require(spec string) string {
+	str, err := f.Get(spec)
+	if err != nil {
+		panic(err)
+	}
+	return str
+}
+
+// Child retrieves a child node from the specified node as follows:
+//   .mapkey   - Get the key 'mapkey' of the Node, which must be a Map
+//   [idx]     - Choose the index from the current Node, which must be a List
+//
+// The above selectors may be applied recursively, and each successive selector
+// applies to the result of the previous selector.  For convenience, a "." is
+// implied as the first character if the first character is not a "." or "[".
+// The node tree is walked from the given node, considering each token of the
+// above format.  If a node along the evaluation path is not found, an error is
+// returned. If a node is not the proper type, an error is returned.  If the
+// final node is not a Scalar, an error is returned.
+func Child(root Node, spec string) (Node, error) {
+	if len(spec) == 0 {
+		return root, nil
+	}
+
+	if first := spec[0]; first != '.' && first != '[' {
+		spec = "." + spec
+	}
+
+	var recur func(Node, string, string) (Node, error)
+	recur = func(n Node, last, s string) (Node, error) {
+
+		if len(s) == 0 {
+			return n, nil
+		}
+
+		if n == nil {
+			return nil, &NodeNotFound{
+				Full: spec,
+				Spec: last,
+			}
+		}
+
+		// Extract the next token
+		delim := 1 + strings.IndexAny(s[1:], ".[")
+		if delim <= 0 {
+			delim = len(s)
+		}
+		tok := s[:delim]
+		remain := s[delim:]
+
+		switch s[0] {
+		case '[':
+			s, ok := n.(List)
+			if !ok {
+				return nil, &NodeTypeMismatch{
+					Node:     n,
+					Expected: "yaml.List",
+					Full:     spec,
+					Spec:     last,
+					Token:    tok,
+				}
+			}
+
+			if tok[0] == '[' && tok[len(tok)-1] == ']' {
+				if num, err := strconv.Atoi(tok[1 : len(tok)-1]); err == nil {
+					if num >= 0 && num < len(s) {
+						return recur(s[num], last+tok, remain)
+					}
+				}
+			}
+			return nil, &NodeNotFound{
+				Full: spec,
+				Spec: last + tok,
+			}
+		default:
+			m, ok := n.(Map)
+			if !ok {
+				return nil, &NodeTypeMismatch{
+					Node:     n,
+					Expected: "yaml.Map",
+					Full:     spec,
+					Spec:     last,
+					Token:    tok,
+				}
+			}
+
+			n, ok = m[tok[1:]]
+			if !ok {
+				return nil, &NodeNotFound{
+					Full: spec,
+					Spec: last + tok,
+				}
+			}
+			return recur(n, last+tok, remain)
+		}
+	}
+	return recur(root, "", spec)
+}
+
+type NodeNotFound struct {
+	Full string
+	Spec string
+}
+
+func (e *NodeNotFound) Error() string {
+	return fmt.Sprintf("yaml: %s: %q not found", e.Full, e.Spec)
+}
+
+type NodeTypeMismatch struct {
+	Full     string
+	Spec     string
+	Token    string
+	Node     Node
+	Expected string
+}
+
+func (e *NodeTypeMismatch) Error() string {
+	return fmt.Sprintf("yaml: %s: type mismatch: %q is %T, want %s (at %q)",
+		e.Full, e.Spec, e.Node, e.Expected, e.Token)
+}

--- a/vendor/github.com/kylelemons/go-gypsy/yaml/doc.go
+++ b/vendor/github.com/kylelemons/go-gypsy/yaml/doc.go
@@ -1,0 +1,142 @@
+// Copyright 2013 Google, Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Gypsy is a simplified YAML parser written in Go.  It is intended to be used as
+// a simple configuration file, and as such does not support a lot of the more
+// nuanced syntaxes allowed in full-fledged YAML.  YAML does not allow indent with
+// tabs, and GYPSY does not ever consider a tab to be a space character.  It is
+// recommended that your editor be configured to convert tabs to spaces when
+// editing Gypsy config files.
+//
+// Gypsy understands the following to be a list:
+//
+//     - one
+//     - two
+//     - three
+//
+// This is parsed as a `yaml.List`, and can be retrieved from the
+// `yaml.Node.List()` method.  In this case, each element of the `yaml.List` would
+// be a `yaml.Scalar` whose value can be retrieved with the `yaml.Scalar.String()`
+// method.
+//
+// Gypsy understands the following to be a mapping:
+//
+//     key:     value
+//     foo:     bar
+//     running: away
+//
+// A mapping is an unordered list of `key:value` pairs.  All whitespace after the
+// colon is stripped from the value and is used for alignment purposes during
+// export.  If the value is not a list or a map, everything after the first
+// non-space character until the end of the line is used as the `yaml.Scalar`
+// value.
+//
+// Gypsy allows arbitrary nesting of maps inside lists, lists inside of maps, and
+// maps and/or lists nested inside of themselves.
+//
+// A map inside of a list:
+//
+//     - name: John Smith
+//       age:  42
+//     - name: Jane Smith
+//       age:  45
+//
+// A list inside of a map:
+//
+//     schools:
+//       - Meadow Glen
+//       - Forest Creek
+//       - Shady Grove
+//     libraries:
+//       - Joseph Hollingsworth Memorial
+//       - Andrew Keriman Memorial
+//
+// A list of lists:
+//
+//     - - one
+//       - two
+//       - three
+//     - - un
+//       - deux
+//       - trois
+//     - - ichi
+//       - ni
+//       - san
+//
+// A map of maps:
+//
+//     google:
+//       company: Google, Inc.
+//       ticker:  GOOG
+//       url:     http://google.com/
+//     yahoo:
+//       company: Yahoo, Inc.
+//       ticker:  YHOO
+//       url:     http://yahoo.com/
+//
+// In the case of a map of maps, all sub-keys must be on subsequent lines and
+// indented equally.  It is allowable for the first key/value to be on the same
+// line if there is more than one key/value pair, but this is not recommended.
+//
+// Values can also be expressed in long form (leading whitespace of the first line
+// is removed from it and all subsequent lines).  In the normal (baz) case,
+// newlines are treated as spaces, all indentation is removed.  In the folded case
+// (bar), newlines are treated as spaces, except pairs of newlines (e.g. a blank
+// line) are treated as a single newline, only the indentation level of the first
+// line is removed, and newlines at the end of indented lines are preserved.  In
+// the verbatim (foo) case, only the indent at the level of the first line is
+// stripped.  The example:
+//
+//     foo: |
+//       lorem ipsum dolor
+//       sit amet
+//     bar: >
+//       lorem ipsum
+//
+//         dolor
+//
+//       sit amet
+//     baz:
+//       lorem ipsum
+//        dolor sit amet
+//
+// The YAML subset understood by Gypsy can be expressed (loosely) in the following
+// grammar (not including comments):
+//
+//               OBJECT = MAPPING | SEQUENCE | SCALAR .
+//         SHORT-OBJECT = SHORT-MAPPING | SHORT-SEQUENCE | SHORT-SCALAR .
+//                  EOL = '\n'
+//
+//              MAPPING = { LONG-MAPPING | SHORT-MAPPING } .
+//             SEQUENCE = { LONG-SEQUENCE | SHORT-SEQUENCE } .
+//               SCALAR = { LONG-SCALAR | SHORT-SCALAR } .
+//
+//         LONG-MAPPING = { INDENT KEY ':' OBJECT EOL } .
+//        SHORT-MAPPING = '{' KEY ':' SHORT-OBJECT { ',' KEY ':' SHORT-OBJECT } '}' EOL .
+//
+//        LONG-SEQUENCE = { INDENT '-' OBJECT EOL } EOL .
+//       SHORT-SEQUENCE = '[' SHORT-OBJECT { ',' SHORT-OBJECT } ']' EOL .
+//
+//          LONG-SCALAR = ( '|' | '>' | ) EOL { INDENT SHORT-SCALAR EOL }
+//         SHORT-SCALAR = { alpha | digit | punct | ' ' | '\t' } .
+//
+//                  KEY = { alpha | digit }
+//               INDENT = { ' ' }
+//
+// Any line where the first non-space character is a sharp sign (#) is a comment.
+// It will be ignored.
+// Only full-line comments are allowed.
+package yaml
+
+// BUG(kevlar): Multi-line strings are currently not supported.

--- a/vendor/github.com/kylelemons/go-gypsy/yaml/parser.go
+++ b/vendor/github.com/kylelemons/go-gypsy/yaml/parser.go
@@ -1,0 +1,374 @@
+// Copyright 2013 Google, Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Parse returns a root-level Node parsed from the lines read from r.  In
+// general, this will be done for you by one of the File constructors.
+func Parse(r io.Reader) (node Node, err error) {
+	lb := &lineBuffer{
+		Reader: bufio.NewReader(r),
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			switch r := r.(type) {
+			case error:
+				err = r
+			case string:
+				err = errors.New(r)
+			default:
+				err = fmt.Errorf("%v", r)
+			}
+		}
+	}()
+
+	node = parseNode(lb, 0, nil)
+	return
+}
+
+// Supporting types and constants
+
+const (
+	typUnknown = iota
+	typSequence
+	typMapping
+	typScalar
+)
+
+var typNames = []string{
+	"Unknown", "Sequence", "Mapping", "Scalar",
+}
+
+type lineReader interface {
+	Next(minIndent int) *indentedLine
+}
+
+type indentedLine struct {
+	lineno int
+	indent int
+	line   []byte
+}
+
+func (line *indentedLine) String() string {
+	return fmt.Sprintf("%2d: %s%s", line.indent,
+		strings.Repeat(" ", 0*line.indent), string(line.line))
+}
+
+func parseNode(r lineReader, ind int, initial Node) (node Node) {
+	first := true
+	node = initial
+
+	// read lines
+	for {
+		line := r.Next(ind)
+		if line == nil {
+			break
+		}
+
+		if len(line.line) == 0 {
+			continue
+		}
+
+		if first {
+			ind = line.indent
+			first = false
+		}
+
+		types := []int{}
+		pieces := []string{}
+
+		var inlineValue func([]byte)
+		inlineValue = func(partial []byte) {
+			// TODO(kevlar): This can be a for loop now
+			vtyp, brk := getType(partial)
+			begin, end := partial[:brk], partial[brk:]
+
+			if vtyp == typMapping {
+				end = end[1:]
+			}
+			end = bytes.TrimLeft(end, " ")
+
+			switch vtyp {
+			case typScalar:
+				types = append(types, typScalar)
+				pieces = append(pieces, string(end))
+				return
+			case typMapping:
+				types = append(types, typMapping)
+				pieces = append(pieces, strings.TrimSpace(string(begin)))
+
+				trimmed := bytes.TrimSpace(end)
+				if len(trimmed) == 1 && trimmed[0] == '|' {
+					text := ""
+
+					for {
+						l := r.Next(1)
+						if l == nil {
+							break
+						}
+
+						s := string(l.line)
+						s = strings.TrimSpace(s)
+						if len(s) == 0 {
+							break
+						}
+						text = text + "\n" + s
+					}
+
+					types = append(types, typScalar)
+					pieces = append(pieces, string(text))
+					return
+				}
+				inlineValue(end)
+			case typSequence:
+				types = append(types, typSequence)
+				pieces = append(pieces, "-")
+				inlineValue(end)
+			}
+		}
+
+		inlineValue(line.line)
+		var prev Node
+
+		// Nest inlines
+		for len(types) > 0 {
+			last := len(types) - 1
+			typ, piece := types[last], pieces[last]
+
+			var current Node
+			if last == 0 {
+				current = node
+			}
+			//child := parseNode(r, line.indent+1, typUnknown) // TODO allow scalar only
+
+			// Add to current node
+			switch typ {
+			case typScalar: // last will be == nil
+				if _, ok := current.(Scalar); current != nil && !ok {
+					panic("cannot append scalar to non-scalar node")
+				}
+				if current != nil {
+					current = Scalar(piece) + " " + current.(Scalar)
+					break
+				}
+				current = Scalar(piece)
+			case typMapping:
+				var mapNode Map
+				var ok bool
+				var child Node
+
+				// Get the current map, if there is one
+				if mapNode, ok = current.(Map); current != nil && !ok {
+					_ = current.(Map) // panic
+				} else if current == nil {
+					mapNode = make(Map)
+				}
+
+				if _, inlineMap := prev.(Scalar); inlineMap && last > 0 {
+					current = Map{
+						piece: prev,
+					}
+					break
+				}
+
+				child = parseNode(r, line.indent+1, prev)
+				mapNode[piece] = child
+				current = mapNode
+
+			case typSequence:
+				var listNode List
+				var ok bool
+				var child Node
+
+				// Get the current list, if there is one
+				if listNode, ok = current.(List); current != nil && !ok {
+					_ = current.(List) // panic
+				} else if current == nil {
+					listNode = make(List, 0)
+				}
+
+				if _, inlineList := prev.(Scalar); inlineList && last > 0 {
+					current = List{
+						prev,
+					}
+					break
+				}
+
+				child = parseNode(r, line.indent+1, prev)
+				listNode = append(listNode, child)
+				current = listNode
+
+			}
+
+			if last < 0 {
+				last = 0
+			}
+			types = types[:last]
+			pieces = pieces[:last]
+			prev = current
+		}
+
+		node = prev
+	}
+	return
+}
+
+func getType(line []byte) (typ, split int) {
+	if len(line) == 0 {
+		return
+	}
+
+	if line[0] == '-' {
+		typ = typSequence
+		split = 1
+		return
+	}
+
+	typ = typScalar
+
+	if line[0] == ' ' || line[0] == '"' {
+		return
+	}
+
+	// the first character is real
+	// need to iterate past the first word
+	// things like "foo:" and "foo :" are mappings
+	// everything else is a scalar
+
+	idx := bytes.IndexAny(line, " \":")
+	if idx < 0 {
+		return
+	}
+
+	if line[idx] == '"' {
+		return
+	}
+
+	if line[idx] == ':' {
+		typ = typMapping
+		split = idx
+	} else if line[idx] == ' ' {
+		// we have a space
+		// need to see if its all spaces until a :
+		for i := idx; i < len(line); i++ {
+			switch ch := line[i]; ch {
+			case ' ':
+				continue
+			case ':':
+				// only split on colons followed by a space
+				if i+1 < len(line) && line[i+1] != ' ' {
+					continue
+				}
+
+				typ = typMapping
+				split = i
+				break
+			default:
+				break
+			}
+		}
+	}
+
+	if typ == typMapping && split+1 < len(line) && line[split+1] != ' ' {
+		typ = typScalar
+		split = 0
+	}
+
+	return
+}
+
+// lineReader implementations
+
+type lineBuffer struct {
+	*bufio.Reader
+	readLines int
+	pending   *indentedLine
+}
+
+func (lb *lineBuffer) Next(min int) (next *indentedLine) {
+	if lb.pending == nil {
+		var (
+			read []byte
+			more bool
+			err  error
+		)
+
+		l := new(indentedLine)
+		l.lineno = lb.readLines
+		more = true
+		for more {
+			read, more, err = lb.ReadLine()
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				panic(err)
+			}
+			l.line = append(l.line, read...)
+		}
+		lb.readLines++
+
+		for _, ch := range l.line {
+			switch ch {
+			case ' ':
+				l.indent += 1
+				continue
+			default:
+			}
+			break
+		}
+		l.line = l.line[l.indent:]
+
+		// Ignore blank lines and comments.
+		if len(l.line) == 0 || l.line[0] == '#' {
+			return lb.Next(min)
+		}
+
+		lb.pending = l
+	}
+	next = lb.pending
+	if next.indent < min {
+		return nil
+	}
+	lb.pending = nil
+	return
+}
+
+type lineSlice []*indentedLine
+
+func (ls *lineSlice) Next(min int) (next *indentedLine) {
+	if len(*ls) == 0 {
+		return nil
+	}
+	next = (*ls)[0]
+	if next.indent < min {
+		return nil
+	}
+	*ls = (*ls)[1:]
+	return
+}
+
+func (ls *lineSlice) Push(line *indentedLine) {
+	*ls = append(*ls, line)
+}

--- a/vendor/github.com/kylelemons/go-gypsy/yaml/types.go
+++ b/vendor/github.com/kylelemons/go-gypsy/yaml/types.go
@@ -1,0 +1,120 @@
+// Copyright 2013 Google, Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// A Node is a YAML Node which can be a Map, List or Scalar.
+type Node interface {
+	write(io.Writer, int, int)
+}
+
+// A Map is a YAML Mapping which maps Strings to Nodes.
+type Map map[string]Node
+
+// Key returns the value associeted with the key in the map.
+func (node Map) Key(key string) Node {
+	return node[key]
+}
+
+func (node Map) write(out io.Writer, firstind, nextind int) {
+	indent := bytes.Repeat([]byte{' '}, nextind)
+	ind := firstind
+
+	width := 0
+	scalarkeys := []string{}
+	objectkeys := []string{}
+	for key, value := range node {
+		if _, ok := value.(Scalar); ok {
+			if swid := len(key); swid > width {
+				width = swid
+			}
+			scalarkeys = append(scalarkeys, key)
+			continue
+		}
+		objectkeys = append(objectkeys, key)
+	}
+	sort.Strings(scalarkeys)
+	sort.Strings(objectkeys)
+
+	for _, key := range scalarkeys {
+		value := node[key].(Scalar)
+		out.Write(indent[:ind])
+		fmt.Fprintf(out, "%-*s %s\n", width+1, key+":", string(value))
+		ind = nextind
+	}
+	for _, key := range objectkeys {
+		out.Write(indent[:ind])
+		if node[key] == nil {
+			fmt.Fprintf(out, "%s: <nil>\n", key)
+			continue
+		}
+		fmt.Fprintf(out, "%s:\n", key)
+		ind = nextind
+		node[key].write(out, ind+2, ind+2)
+	}
+}
+
+// A List is a YAML Sequence of Nodes.
+type List []Node
+
+// Get the number of items in the List.
+func (node List) Len() int {
+	return len(node)
+}
+
+// Get the idx'th item from the List.
+func (node List) Item(idx int) Node {
+	if idx >= 0 && idx < len(node) {
+		return node[idx]
+	}
+	return nil
+}
+
+func (node List) write(out io.Writer, firstind, nextind int) {
+	indent := bytes.Repeat([]byte{' '}, nextind)
+	ind := firstind
+
+	for _, value := range node {
+		out.Write(indent[:ind])
+		fmt.Fprint(out, "- ")
+		ind = nextind
+		value.write(out, 0, ind+2)
+	}
+}
+
+// A Scalar is a YAML Scalar.
+type Scalar string
+
+// String returns the string represented by this Scalar.
+func (node Scalar) String() string { return string(node) }
+
+func (node Scalar) write(out io.Writer, ind, _ int) {
+	fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", ind), string(node))
+}
+
+// Render returns a string of the node as a YAML document.  Note that
+// Scalars will have a newline appended if they are rendered directly.
+func Render(node Node) string {
+	buf := bytes.NewBuffer(nil)
+	node.write(buf, 0, 0)
+	return buf.String()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,0 +1,2 @@
+# github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28
+github.com/kylelemons/go-gypsy/yaml


### PR DESCRIPTION
Add [Go module](https://github.com/golang/go/wiki/Modules) support to simplify download and build:

```
git clone https://github.com/jamesog/tarsnapmanager
cd tarsnapmanager
go build
```

To avoid fetching dependencies from the Internet and instead use the local `vendor/` copy, build with `go build -mod=vendor`